### PR TITLE
feat(team-members): add functionality to pause a team member

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -2,6 +2,8 @@ export interface TeamMate {
   name: string;
   isDone: boolean;
   selected: boolean;
+  isPaused: boolean;
+  time: number;
 }
 
 interface TimeLeft {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,6 @@
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "noImplicitAny": true,
-    "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
     "noUnusedLocals": true
   },


### PR DESCRIPTION

**What does this PR do?**

Adds functionality to pause a team member talking

**Description of Task to be completed?**

If a user is temporarily cut short while talking I should be able to pause their time and continue it after they resume

**How should this be manually tested?**

Open the team member list click on the team member then click on them again after the timer starts the timer should stop temporarily

**Any background context you want to provide?**

xxx

**What are the relevant pivotal tracker stories?**

[#159817772](https://www.pivotaltracker.com/story/show/159817772)

**Screenshots (if appropriate)**

xxx

**Questions:**

xxx
