### PR TITLE
Make entire team member card clickable

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -84,6 +84,10 @@
         padding: 4px;
         border: 1px solid #FFAF30;
         cursor: pointer;
+
+        &-container {
+          flex: 2;
+        }
       }
 
       &-item:hover {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -103,7 +103,8 @@ class App extends React.Component<{}, AppState>{
                   >
                     <div
                       className="main-page__container__list-item-container"
-                      onClick={this.handleTeamMateTime(teamMember)}>
+                      onClick={this.handleTeamMateTime(teamMember)}
+                      >
                         <div className="main-page__list-item__name">{`${teamMember.name}`}</div>
                         {
                           teamMember.selected 
@@ -114,10 +115,12 @@ class App extends React.Component<{}, AppState>{
                           teamMember.isDone &&  <div className="main-page__container__check">&#x2714;</div>
                         }
                     </div>
-                    <img
-                      className="main-page__container__delete-icon"
-                      src="https://res.cloudinary.com/mikekrantz/image/upload/v1537265689/delete.svg"
-                      onClick={this.deleteMember(teamMember)}/>
+                    <div onClick={this.deleteMember(teamMember)}>
+                      <img
+                        className="main-page__container__delete-icon"
+                        src="https://res.cloudinary.com/mikekrantz/image/upload/v1537265689/delete.svg"
+                        />
+                      </div>
                   </div>
                 ))
               }


### PR DESCRIPTION
**What does this PR do?**
Not sure if this was the inntended functionality, but the app only responds when I click on the name of the member. If I clicked anywhere else on the card, nothing happens. This PR Makes the entire team member card clickable.

**Description of Task to be completed?**
Make the team-member card clickable.

**How should this be manually tested?**
After cloning the branch, run `npm install` to ensure you have all dependencies installed. Run `npm start` to start the application. Click on a team-member card to start the timer.

**Any background context you want to provide?**
Clicking on the name alone might not be the best user experience for a user. Making the entire card clickable affords the user some sort of flexibility

**What are the relevant pivotal tracker stories?**

N/A

**Screenshots (if appropriate)**

N/A

**Questions:**

N/A